### PR TITLE
fix(yahoofinancials): yahoofinancials 1.6 -> 1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ PyYAML==5.4.1
 regex==2021.4.4
 slack-sdk==3.5.1
 toml==0.10.2
-yahoofinancials==1.6
+yahoofinancials==1.7


### PR DESCRIPTION
Error and explanation of the fix:
https://stackoverflow.com/questions/74831541/python-module-yahoofinancials-typeerror-string-indices-must-be-integers